### PR TITLE
obs-db/data: keep Factory on GNOME 3.12 for now

### DIFF
--- a/server/obs-db/data/opensuse.conf
+++ b/server/obs-db/data/opensuse.conf
@@ -16,6 +16,7 @@ branches = latest, cpan, fallback
 [Project openSUSE:Factory]
 parent = openSUSE:Factory
 checkout-devel-projects = True
+branches = gnome-3.12, gnome-3.12-extras
 
 # For 12.2
 [Project GNOME:STABLE:3.6]


### PR DESCRIPTION
We should freeze factory for now on 3.12; 3.14 packages live in GNOME:Next until we're nearing stable releases...
