### PR TITLE
Some more packages we maintain

### DIFF
--- a/server/upstream/upstream-packages-match.txt
+++ b/server/upstream/upstream-packages-match.txt
@@ -140,6 +140,7 @@ dasher:
 dbus-glib:dbus-1-glib
 dbus:dbus-1
 dconf:
+dconf-editor:
 dd_rescue:
 ddrescue:gnu_ddrescue
 decibel-audio-player:
@@ -161,6 +162,7 @@ docky:
 dogtail:
 drwright:
 dwarves:
+easytag:
 ed:
 editres:
 eds-feed:evolution-galago
@@ -820,6 +822,7 @@ nss-mdns:
 ntfs-3g_ntfsprogs:ntfs-3g
 ntfs-3g_ntfsprogs:ntfs-3g_ntfsprogs
 ntfs-config:
+nuntius:
 obby:
 obex-data-server:
 oclock:
@@ -834,6 +837,7 @@ opus:
 orc:
 orca:
 osm-gps-map:
+ostree:
 p11-kit:
 padevchooser:
 pam_mount:
@@ -1083,6 +1087,7 @@ xcursor-themes:
 xcursorgen:
 xdbedizzy:
 xdelta:
+xdg-app:
 xdg-user-dirs-gtk:
 xdg-user-dirs:
 xdg-utils:

--- a/server/upstream/upstream-packages-match.txt
+++ b/server/upstream/upstream-packages-match.txt
@@ -684,6 +684,8 @@ libgusb:
 libgweather:
 libgxps:
 libhangul:
+libical:
+libical-glib:
 libinfinity:
 libiptcdata:
 libjingle:

--- a/server/upstream/upstream-tarballs.txt
+++ b/server/upstream/upstream-tarballs.txt
@@ -427,6 +427,7 @@ libgrss:httpls:http://gtk.mplat.es/libgrss/tarballs/
 libgsasl:httpls:http://ftp.gnu.org/pub/gnu/gsasl/
 libgusb:httpls:http://people.freedesktop.org/~hughsient/releases/
 libhangul:google:libhangul
+libical:sf:16077
 libinfinity:httpls:http://releases.0x539.de/libinfinity/
 libiptcdata:sf:130582|libiptcdata
 libjingle:httpls:http://farsight.freedesktop.org/releases/obsolete/libjingle/


### PR DESCRIPTION
*dconf-editor has been split out of dconf
* easytag: has been with us for a long time, but never tracked
* nuntius: new upstream package, maintained on github for now
* ostree: something between chroot and containers
* xdg-app: containerized applications