### PR TITLE
Update upstream-tarballs.txt

### DIFF
--- a/server/upstream/upstream-tarballs.txt
+++ b/server/upstream/upstream-tarballs.txt
@@ -81,6 +81,7 @@ DeviceKit-power:httpls:http://upower.freedesktop.org/releases/
 DeviceKit:httpls:http://hal.freedesktop.org/releases/
 LaTeXPlugin:sf:204144
 LibRaw:httpls:http://www.libraw.org/download
+ModemManager:httpls:http://www.freedesktop.org/software/ModemManager/
 NetworkManager-strongswan:httpls:http://download.strongswan.org/NetworkManager/
 PackageKit:httpls:http://www.freedesktop.org/software/PackageKit/releases/
 PackageKit-Qt:httpls:http://www.freedesktop.org/software/PackageKit/releases/


### PR DESCRIPTION
ModemManager moved to freedesktop 2 years ago, about time we fix the url.
Make sure I've done all thats needed ;-)