### PR TITLE
Add ability to parse tarball version prefixed with v

### DIFF
--- a/server/upstream/download-upstream-versions
+++ b/server/upstream/download-upstream-versions
@@ -366,7 +366,7 @@ def _get_version_from_files(modulename, location, files, limit):
         tarballs_new.append(tarball)
     tarballs = tarballs_new
 
-    re_tarball = r'^.*'+modulename+'[_-](([0-9]+[\.\-])*[0-9]+)\.(?:tar.*|t[bg]z2?)$'
+    re_tarball = r'^.*'+modulename+'[_-]:v?(([0-9]+[\.\-])*[0-9]+)\.(?:tar.*|t[bg]z2?)$'
     # Don't include -beta -installer -stub-installer and all kinds of
     # other weird-named tarballs
     tarballs = filter(lambda t: re.search(re_tarball, t), tarballs)


### PR DESCRIPTION
There are tarballs that are not caught if the file name looks like

  modue-name-v1.2.tar.gz