### PR TITLE
Add upstream urls for subset of obs://filesystems packages

### DIFF
--- a/server/upstream/upstream-tarballs.txt
+++ b/server/upstream/upstream-tarballs.txt
@@ -104,6 +104,7 @@ arping:httpls:http://www.habets.pp.se/synscan/files/
 asio:sf:122478|asio
 atheme-services:httpls:http://atheme.net/downloads/
 autocutsel:httpls:http://download.savannah.gnu.org/releases/autocutsel/
+autofs:httpls:https://kernel.org/pub/linux/daemons/autofs/v5/
 avahi:httpls:http://avahi.org/download/
 babl:subdirhttpls:http://ftp.gtk.org/pub/babl/
 bakefile:sf:83016|bakefile
@@ -112,12 +113,17 @@ banshee-community-extensions:subdirhttpls:http://download.banshee.fm/banshee-com
 bash-completion:httpls:http://bash-completion.alioth.debian.org/files/
 bdftopcf:httpls:http://xorg.freedesktop.org/releases/individual/app/
 beforelight:httpls:http://xorg.freedesktop.org/releases/individual/app/
+bfsync:httpls:http://space.twc.de/~stefan/bfsync/
+bindfs:httpls:http://bindfs.org/downloads/
 bitmap:httpls:http://xorg.freedesktop.org/releases/individual/app/
+blktrace:httpls:http://brick.kernel.dk/snaps/
 blueproximity:sf:203022
 bombermaze:sf:8614|bombermaze
 bot-sentry:sf:156021|bot-sentry
 brltty:httpls:http://mielke.cc/brltty/releases/
+btrfsprogs:httpls:https://www.kernel.org/pub/linux/kernel/people/kdave/btrfs-progs/
 c++-gtk-utils:sf:277143|cxx-gtk-utils
+cachefilesd:httpls:http://people.redhat.com/~dhowells/fscache/
 cairo-clock:httpls:http://macslow.net/?page_id=23
 cairo-compmgr:httpls:http://download.tuxfamily.org/ccm/cairo-compmgr/
 cairo:dualhttpls:http://cairographics.org/snapshots/|http://cairographics.org/releases/
@@ -125,6 +131,7 @@ cairomm:dualhttpls:http://cairographics.org/snapshots/|http://cairographics.org/
 ccgfs:sf:207310
 ccsm:subdirhttpls:http://releases.compiz.org/components/ccsm/
 cdecl:httpls:http://www.gtlib.cc.gatech.edu/pub/Linux/devel/lang/c/
+cdfs:httpls:https://users.elis.ugent.be/~mronsse/cdfs/download/
 check:sf:28255|check
 cherrytree:httpls:http://www.giuspen.com/software/
 chmlib:httpls:http://www.jedrea.com/chmlib/
@@ -132,6 +139,7 @@ chmsee:google:chmsee
 claws-mail-extra-plugins:sf:25528|extra plugins
 claws-mail:sf:25528|Claws Mail
 cloop:httpls:http://debian-knoppix.alioth.debian.org/packages/cloop/
+cmsfs:httpls:http://www.linuxvm.org/Patches
 cmuclmtk:sf:1904|cmuclmtk
 colorblind:httpls:https://alioth.debian.org/frs/?group_id=31117
 colord:httpls:http://www.freedesktop.org/software/colord/releases/
@@ -148,8 +156,10 @@ compizconfig-python:subdirhttpls:http://releases.compiz.org/components/compizcon
 computertemp:httpls:http://computertemp.berlios.de/download.php
 conglomerate:sf:82766|Conglomerate XML Editor
 conntrack-tools:httpls:http://ftp.netfilter.org/pub/conntrack-tools/
+cromfs:httpls:http://bisqwit.iki.fi/source/cromfs.html
 csmash:sf:4179|CannonSmash
 cups-pk-helper:httpls:http://www.freedesktop.org/software/cups-pk-helper/releases/
+davfs2:httpls:http://download.savannah.gnu.org/releases/davfs2/
 dbus-glib:httpls:http://dbus.freedesktop.org/releases/dbus-glib/
 dbus:httpls:http://dbus.freedesktop.org/releases/dbus/
 dd_rescue:httpls:http://garloff.de/kurt/linux/ddrescue/
@@ -163,8 +173,10 @@ devilspie:httpls:http://www.burtonini.com/computing/
 diffutils:httpls:http://ftp.gnu.org/gnu/diffutils/
 ding:httpls:http://ftp.tu-chemnitz.de/pub/Local/urz/ding/
 djvulibre:sf:32953|DjVuLibre
+dmapi:httpls:ftp://oss.sgi.com/projects/xfs/cmd_tars/
 dmlangsel:google:loolixbodes|dmlangsel
 docky:lp:docky
+duperemove:httpls:https://github.com/markfasheh/duperemove/releases
 dwarves:httpls:http://fedorapeople.org/~acme/dwarves/
 ed:httpls:http://ftp.gnu.org/gnu/ed/
 editres:httpls:http://xorg.freedesktop.org/releases/individual/app/
@@ -346,6 +358,7 @@ ico:httpls:http://xorg.freedesktop.org/releases/individual/app/
 icon-naming-utils:httpls:http://tango.freedesktop.org/releases/
 imake:httpls:http://xorg.freedesktop.org/releases/individual/util/
 inkscape:sf:93438|inkscape
+inotify-tools:httpls:http://github.com/rvoicilas/inotify-tools/releases
 input-pad:google:input-pad
 intel-gpu-tools:httpls:http://xorg.freedesktop.org/releases/individual/app/
 intltool:lp:intltool
@@ -403,9 +416,11 @@ libXxf86vm:httpls:http://xorg.freedesktop.org/releases/individual/lib/
 libao-pulse:httpls:http://0pointer.de/lennart/projects/libao-pulse/
 libassuan:ftpls:ftp://ftp.gnupg.org/gcrypt/libassuan/
 libatasmart:httpls:http://0pointer.de/public/
+libatomic_ops:httpls:http://www.ivmaisoft.com/_bin/atomic_ops/
 libbraille:sf:17127|libbraille
 libbs2b:sf:151236
 libcanberra:httpls:http://0pointer.de/lennart/projects/libcanberra/
+libcares2:httpls:http://c-ares.haxx.se/download/
 libchewing:google:chewing|libchewing
 libcompizconfig:subdirhttpls:http://releases.compiz.org/components/libcompizconfig/
 libdaemon:httpls:http://0pointer.de/lennart/projects/libdaemon/
@@ -537,6 +552,7 @@ openfetion:google:ofetion|openfetion
 openobex:httpls:http://www.kernel.org/pub/linux/bluetooth/
 opus:httpls:http://downloads.xiph.org/releases/opus/
 orc:httpls:http://code.entropywave.com/download/orc/
+ori:httpls:https://bitbucket.org/orifs/ori/downloads/
 osm-gps-map:httpls:https://github.com/nzjrs/osm-gps-map/releases/
 p11-kit:httpls:http://p11-glue.freedesktop.org/releases/
 padevchooser:httpls:http://0pointer.de/lennart/projects/padevchooser/
@@ -605,6 +621,7 @@ rep-gtk:httpls:http://download.tuxfamily.org/librep/rep-gtk/
 rgb:httpls:http://xorg.freedesktop.org/releases/individual/app/
 rlwrap:httpls:http://utopia.knoware.nl/~hlub/rlwrap/
 rstart:httpls:http://xorg.freedesktop.org/releases/individual/app/
+s3backer:httpls:https://s3.amazonaws.com/archie-public/s3backer
 sawfish:httpls:http://download.tuxfamily.org/sawfish/
 schismtracker:httpls:http://schismtracker.org/dl/
 schroedinger:httpls:http://diracvideo.org/download/schroedinger/
@@ -636,6 +653,7 @@ shared-mime-info:httpls:http://people.freedesktop.org/~hadess/
 shotwell:subdirhttpls:http://yorba.org/download/shotwell/
 showfont:httpls:http://xorg.freedesktop.org/releases/individual/app/
 simple-ccsm:subdirhttpls:http://releases.compiz.org/components/simple-ccsm/
+simple-mtpfs:httpls:http://github.com/phatina/simple-mtpfs/releases
 simple-scan:lp:simple-scan
 smproxy:httpls:http://xorg.freedesktop.org/releases/individual/app/
 smuxi:httpls:http://www.smuxi.org/jaws/data/files/
@@ -681,6 +699,7 @@ telepathy-stream-engine:httpls:http://telepathy.freedesktop.org/releases/stream-
 tig:httpls:http://jonas.nitro.dk/tig/releases/
 tilda:sf:126081|tilda
 tinyproxy:httpls:https://banu.com/tinyproxy/
+tokyocabinet:httpls:http://fallabs.com/tokyocabinet/
 traffic-vis:httpls:http://www.mindrot.org/traffic-vis.html
 transmageddon:httpls:http://www.linuxrising.org/files/
 transmission:httpls:http://download.m0k.org/transmission/files/
@@ -694,6 +713,7 @@ uget:sf:72252|Uget (stable)
 uhttpmock:httpls:https://tecnocode.co.uk/downloads/uhttpmock/
 ulogd:httpls:http://ftp.netfilter.org/pub/ulogd/
 unico:lp:unico
+unionfs-fuse:httpls:https://github.com/rpodgorny/unionfs-fuse/releases
 upower:httpls:http://upower.freedesktop.org/releases/
 usbredir:httpls:http://spice-space.org/download/usbredir/
 usbview:httpls:http://www.kroah.com/linux-usb/
@@ -703,6 +723,7 @@ varnish:httpls:http://repo.varnish-cache.org/source/
 vboxgtk:google:vboxgtk
 viewres:httpls:http://xorg.freedesktop.org/releases/individual/app/
 vim:ftpls:ftp://ftp.vim.org/pub/vim/unix/
+vmfs-tools:httpls:http://glandium.org/projects/vmfs-tools/
 vobject:httpls:http://vobject.skyhouseconsulting.com/
 wadptr:httpls:http://soulsphere.org/projects/wadptr/
 weather-wallpaper:httpls:http://mundogeek.net/weather-wallpaper/
@@ -780,8 +801,10 @@ xf86-video-voodoo:httpls:http://xorg.freedesktop.org/releases/individual/driver/
 xfd:httpls:http://xorg.freedesktop.org/releases/individual/app/
 xfindproxy:httpls:http://xorg.freedesktop.org/releases/individual/app/
 xfontsel:httpls:http://xorg.freedesktop.org/releases/individual/app/
+xfsdump:httpls:ftp://oss.sgi.com/projects/xfs/cmd_tars/
 xfs:httpls:http://xorg.freedesktop.org/releases/individual/app/
 xfsinfo:httpls:http://xorg.freedesktop.org/releases/individual/app/
+xfsprogs:httpls:ftp://oss.sgi.com/projects/xfs/cmd_tars/
 xfwp:httpls:http://xorg.freedesktop.org/releases/individual/app/
 xgamma:httpls:http://xorg.freedesktop.org/releases/individual/app/
 xgc:httpls:http://xorg.freedesktop.org/releases/individual/app/


### PR DESCRIPTION
The list of new packages to check:

autofs
bfsync
bindfs
blktrace
btrfsprogs
cachefilesd
cdfs
cmsfs
cromfs
davfs2
dmapi
duperemove
inotify-tools
libatomic_ops
libcares2
ori
s3backer
simple-mtpfs
tokyocabinet
unionfs-fuse
vmfs-tools
xfsdump
xfsprogs

All upstream urls were manually verified that they contain the tarball
versions.