### PR TITLE
NetworkManager-gnome renamed

### DIFF
--- a/server/upstream/upstream-packages-match.txt
+++ b/server/upstream/upstream-packages-match.txt
@@ -845,7 +845,7 @@ nemiver:
 neon:
 net6:
 netspeed_applet:gnome-netspeed-applet
-network-manager-applet:NetworkManager-gnome
+network-manager-applet:NetworkManager-applet
 nimbus:gtk2-metatheme-nimbus
 njb-sharp:
 notification-daemon:


### PR DESCRIPTION
NetworkManager got renamed to NetworkManager-applet in distro.
