### PR TITLE
runme: cleanup obsolete download_gnome_verison calls

### DIFF
--- a/server/obs-db/data/opensuse.conf
+++ b/server/obs-db/data/opensuse.conf
@@ -23,7 +23,7 @@ branches = gnome-3.12, gnome-3.12-extras
 
 # For Leap 42.2
 [Project GNOME:STABLE:3.20]
-branches = gnome-3.20, gnome-3.20-extra
+branches = gnome-3.20, gnome-3.20-extras
 
 # For Factory + 1
 [Project GNOME:Next]

--- a/server/upstream/runme
+++ b/server/upstream/runme
@@ -315,8 +315,6 @@ mkdir -p $CACHE_DIR/upstream
 
 download_gnome_version 3.12
 download_gnome_version 3.12-extras
-download_gnome_version 3.20
-download_gnome_version 3.20-extras
 # Disabled because of infrastructure change on GNOME servers
 #download_gnome_version stable
 #download_gnome_version unstable


### PR DESCRIPTION
This was introduced back in the time when we wanted to track GNOME:STABLE:3.20 - but this is obsolete and causes new issues (this is the code that relies www.gnome.org/~vunty)