### PR TITLE
Track GNOME 41 for Leap 15.4 and SLE15SP4

### DIFF
--- a/server/obs-db/data/opensuse.conf
+++ b/server/obs-db/data/opensuse.conf
@@ -24,6 +24,10 @@ branches = gnome-stable, gnome-stable-extras
 [Project GNOME:Next]
 branches = gnome-unstable, gnome-unstable-extras
 
+# For Leap 15.4 / SLE15SP4
+[Project GNOME:STABLE:41]
+branches = gnome-41, gnome-41-extras
+
 # For Leap 15.2 / SLE15SP2
 [Project GNOME:STABLE:3.34]
 branches = gnome-3.34, gnome-3.34-extras


### PR DESCRIPTION
Track GNOME 41 so that we can use osc collab to track GNOME:STABLE:41.